### PR TITLE
Modificado el número de vidas del enemigo final.

### DIFF
--- a/src/main/kotlin/Game.kt
+++ b/src/main/kotlin/Game.kt
@@ -21,6 +21,7 @@ class Game {
     var prevTime = 0L
     val ship = ShipData()
     var finalBossEliminado: Boolean = false
+    var contadorFinalBossVisible: Boolean = false
 
     var targetLocation by mutableStateOf<DpOffset>(DpOffset.Zero)
 
@@ -28,7 +29,7 @@ class Game {
     var gameState by mutableStateOf(GameState.RUNNING)
     var gameStatus by mutableStateOf("Let's play!")
 
-    var vidasFinalBoss:Int = 3
+    var vidasFinalBoss:Int = 11
 
     fun startGame() {
         gameObjects.clear()
@@ -124,12 +125,8 @@ class Game {
                     if (enemy is FinalBossData) {
                         // Bullet <-> FinalBoss interaction
                         if (enemy.position.distanceTo(least.position) < enemy.size) {
-                            //gameObjects.remove(enemy)
                             gameObjects.remove(least)
-                            print(vidasFinalBoss)
-                            if (vidasFinalBoss > 0){
-                            }
-                                vidasFinalBoss--
+                            vidasFinalBoss--
                             if (vidasFinalBoss <= 0) {
                                 finalBossEliminado = true
                                 gameObjects.remove(enemy)
@@ -147,11 +144,6 @@ class Game {
         }
 
         // Win LEVEL 1 condition
-        /*if (listaEnemigosTotales.isEmpty() && !finalBossEliminado) {
-            showFinalBoss()
-        }*/
-
-        // Win FINAL condition
         if (listaEnemigosTotales.isEmpty() && !finalBossEliminado) {
             showFinalBoss()
         }
@@ -162,6 +154,9 @@ class Game {
         gameObjects.add(FinalBossData().apply {
             position = Vector2(100.0, 100.0); angle = Random.nextDouble() * 360.0; speed = 2.0
         })
+
+        contadorFinalBossVisible = true
+        //vidasFinalBoss--
         /*val bullets = gameObjects.filterIsInstance<BulletData>()
         var vidasFinalBoss = 3
         val finalBoss = gameObjects.filterIsInstance<FinalBossData>()*/

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 fun main() = Window(size = IntSize(800, 900), title = "Asteroids for Desktop") {
     val game = remember { Game() }
     val density = LocalDensity.current
+    var textoVidasBoss = ""
     LaunchedEffect(Unit) {
         while (true) {
             withFrameNanos {
@@ -37,6 +38,9 @@ fun main() = Window(size = IntSize(800, 900), title = "Asteroids for Desktop") {
                 Text("Play")
             }
             Text(game.gameStatus, modifier = Modifier.align(Alignment.CenterVertically).padding(horizontal = 16.dp), color = Color.White)
+            if(game.vidasFinalBoss <= 10) textoVidasBoss = "Vidas final boss: ${game.vidasFinalBoss}"
+            else textoVidasBoss = ""
+            Text(textoVidasBoss, modifier = Modifier.align(Alignment.CenterVertically).padding(horizontal = 16.dp), color = Color.White)
         }
         Box(modifier = Modifier
             .aspectRatio(1.0f)
@@ -50,7 +54,7 @@ fun main() = Window(size = IntSize(800, 900), title = "Asteroids for Desktop") {
                 .clipToBounds()
                 .pointerMoveFilter(onMove = {
                     with(density) {
-                        game.targetLocation  = DpOffset(it.x.toDp(), it.y.toDp())
+                        game.targetLocation = DpOffset(it.x.toDp(), it.y.toDp())
                     }
                     false
                 })


### PR DESCRIPTION
El enemigo final (final boss) ahora tiene definido un número de vidas mayor: es necesario dispararle 10 veces hasta vencerle.

Además, cuando aparezca este enemigo final, aparecerá un contador en la barra superior con el número de vidas restantes del mismo.